### PR TITLE
Add an escape switch for timed out threads.

### DIFF
--- a/Invoke-Parallel.ps1
+++ b/Invoke-Parallel.ps1
@@ -243,7 +243,7 @@
 							if ($PassThru) { $runspace.object }
 
                             #Depending on how it hangs, we could still get stuck here as dispose calls a synchronous method on the powershell instance
-                            if ($noCloseOnTimeout) { $runspace.powershell.dispose() }
+                            if (!$noCloseOnTimeout) { $runspace.powershell.dispose() }
                             $runspace.Runspace = $null
                             $runspace.powershell = $null
                             $completedCount++


### PR DESCRIPTION
I'd commented on the TechNet Gallery a way to handle hangs from timed out threads (by leaking memory). With this PR I've encapsulated that within the -noCloseOnTimeout switch. When the switch is used, powershell.dispose() will not be called on timed out threads and the runspace.close() will be skipped if any threads had timed out. If there are no time outs then it works the same as previously.

I also moved the timed out thread logging to occur before the call to dispose.

I don't have a way to test hanging a thread on-demand, but it was happening it my environment today so I had the opportunity to test this change with and without the switch. 
