### PR TITLE
Fixed typo in help

### DIFF
--- a/New-DynamicParam.ps1
+++ b/New-DynamicParam.ps1
@@ -122,7 +122,7 @@
                 #If no corresponding variable exists, one is created
                     #Get common parameters, pick out bound parameters not in that set
                     Function _temp { [cmdletbinding()] param() }
-                    $BoundLeys = $PSBoundParameters.keys | Where-Object { (get-command _temp | select -ExpandProperty parameters).Keys -notcontains $_}
+                    $BoundKeys = $PSBoundParameters.keys | Where-Object { (get-command _temp | select -ExpandProperty parameters).Keys -notcontains $_}
                     foreach($param in $BoundKeys)
                     {
                         if (-not ( Get-Variable -name $param -scope 0 -ErrorAction SilentlyContinue ) )


### PR DESCRIPTION
Note: `$PSBoundParameters` and corresponding variables in the `Begin` section are not available if the function arguments were passed via pipeline. So if one ever happen to implement support for the
`ValueFromPipeline` attribute, the code that recreates variables from the bound parameters in examples will need to be moved to the Process block.

P.S. Thanks for the inspiration, I've took a liberty to extend your function to support full range of attributes and made a recreation of the variables from the bound paramerts a bit easier: [New-DynamicParameter.ps1](https://github.com/beatcracker/Powershell-Misc/blob/master/New-DynamicParameter.ps1). I'm not sure if I should make a pull request for this, because there is not much left of the your original code. What do you think?