### PR TITLE
Join-Object: support empty collections

### DIFF
--- a/Join-Object.ps1
+++ b/Join-Object.ps1
@@ -200,10 +200,12 @@
     (
         [Parameter(Mandatory=$true,
                    ValueFromPipeLine = $true)]
+        [AllowEmptyCollection()]
         [object[]] $Left,
 
         # List to join with $Left
         [Parameter(Mandatory=$true)]
+        [AllowEmptyCollection()]
         [object[]] $Right,
 
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
This seems pointless, but can be handy when handling variable input in a script.