### PR TITLE
Create Get-ScriptDirectory

### DIFF
--- a/Get-ScriptDirectory
+++ b/Get-ScriptDirectory
@@ -1,0 +1,3 @@
+function Get-ScriptDirectory {
+    Split-Path -parent $script:MyInvocation.MyCommand.Path
+}


### PR DESCRIPTION
Retrieves the directory the current script was stored in. Useful to write scripts whose behavior is relative to the currently executing script, as opposed to the last Set-Location (cd) call or Push-Location (pushd) call.