### PR TITLE
Updated WFTools PowerShellGallery URL to latest stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PowerShell
 
-Various PowerShell functions and scripts.  These are published as [WFTools](https://www.powershellgallery.com/packages/WFTools/0.1.39) on the PowerShell Gallery (thanks to @psrdrgz for the idea!)
+Various PowerShell functions and scripts.  These are published as [WFTools](https://www.powershellgallery.com/packages/WFTools/) on the PowerShell Gallery (thanks to @psrdrgz for the idea!)
 
 Two functions have been migrated to their own repositories to simplify and enable improved collaboration.  Copies remain here for historical purposes and may be updated:
 

--- a/Test-Credential.ps1
+++ b/Test-Credential.ps1
@@ -50,16 +50,16 @@
     #>
     [cmdletbinding(DefaultParameterSetName = 'Domain')]
     param(
-        [parameter(ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline=$true,Position=0)]
         [System.Management.Automation.PSCredential]$Credential = $( Get-Credential -Message "Please provide credentials to test" ),
 
-        [validateset('Domain','Machine', 'ApplicationDirectory')]
+        [ValidateSet('Domain','Machine', 'ApplicationDirectory')]
         [string]$Context = 'Domain',
         
-        [parameter(ParameterSetName = 'Machine')]
+        [Parameter(ParameterSetName = 'Machine')]
         [string]$ComputerName,
 
-        [parameter(ParameterSetName = 'Domain')]
+        [Parameter(ParameterSetName = 'Domain')]
         [string]$Domain = $null
     )
     Begin


### PR DESCRIPTION
If you leave off the version number, PowerShellGallery.com will automatically forward the developer to the WFTools' latest version URL.