### PR TITLE
Fix for Json arrays with only one child object

### DIFF
--- a/ConvertTo-FlatObject.ps1
+++ b/ConvertTo-FlatObject.ps1
@@ -311,8 +311,14 @@
                             continue
                         }
 
-                    #Check for arrays
-                        $IsArray = @($ChildValue).count -gt 1
+                     #Check for arrays by checking object type (this is a fix for arrays with 1 object) otherwise check the count of objects
+                        if (($ChildValue.GetType()).basetype.Name -eq "Array") {
+                            $IsArray = $true
+                        }
+                        else {
+                            $IsArray = @($ChildValue).count -gt 1
+                        }
+
                         $count = 0
 
                     #Set up the path to this node and the data...


### PR DESCRIPTION
Would previously not return the child objects in a one item array.

eg.

"item": [
    {
     "someproperty": "somevalue"
    }
]

Would not get returned properly and would instead return as item.count with a value of 1.

This pull request detects if it's an array using powershell object types.